### PR TITLE
Update compatibility to allow eleventy beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"node": ">=14.18"
 	},
 	"11ty": {
-		"compatibility": ">=2.0.0-canary.19"
+		"compatibility": ">=2.0.0-canary.19 || >=2.0.0-beta.1"
 	},
 	"funding": {
 		"type": "opencollective",


### PR DESCRIPTION
Right now when using the beta it triggers a warning. Adding the beta as a compatibility removes it.

```
WARN: Eleventy Plugin (@11ty/eleventy-plugin-webc) Compatibility: This project requires the Eleventy version to match '>=2.0.0-canary.19' but found 2.0.0-beta.1
```