### PR TITLE
test(global-data): Add test for using global data

### DIFF
--- a/test/global-data/_data/index.js
+++ b/test/global-data/_data/index.js
@@ -1,0 +1,5 @@
+module.exports = new Map([
+	['key1', 'val1'],
+	['key2', 'val2'],
+	['key3', 'val3']
+])

--- a/test/global-data/_includes/global-data-component.webc
+++ b/test/global-data/_includes/global-data-component.webc
@@ -1,0 +1,24 @@
+<script webc:setup>
+	//	check sanity (b/c I can’t get this to work…)
+	console.log('this.index', this.index)
+</script>
+
+<!---
+<script webc:setup>
+	const dataEntry = ([key, val]) => `<dt>${key}</dt><dd>${val}</dd>`
+	const dataContent = []
+	for ([key, val] of index) {
+		dataContent.push(dataEntry([key, val]))
+	}
+	return `<dl>
+		${dataContent.join('\n')}
+	</dl>`
+</script>
+--->
+
+<dl>
+	<template webc:nokeep webc:for="(key, val) of this.index">
+		<dt @text="key"></dt>
+		<dd @text="val"></dd>
+	</template>
+</dl>

--- a/test/global-data/_layouts/layout.webc
+++ b/test/global-data/_layouts/layout.webc
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="description" content="">
+		<title></title>
+		<style webc:keep @html="this.getCSS(this.page.url)"></style>
+		<script webc:keep @html="this.getJS(this.page.url)"></script>
+	</head>
+	<body>
+
+		<template webc:nokeep @html="this.content"></template>
+
+		<style webc:keep @html="this.getCSS(this.page.url, 'defer')"></style>
+		<script webc:keep @html="this.getJS(this.page.url, 'defer')"></script>
+	</body>
+</html>

--- a/test/global-data/eleventy.config.js
+++ b/test/global-data/eleventy.config.js
@@ -1,0 +1,16 @@
+const EleventyWebcPlugin = require("../../eleventyWebcPlugin.js");
+
+module.exports = function (eleventyConfig) {
+	eleventyConfig.addPlugin(EleventyWebcPlugin, {
+    components: "test/global-data/_includes/**/*.webc"
+  });
+  // eleventyConfig.addPlugin(EleventyWebcPlugin);
+
+	return {
+		dir: {
+			data: "_data",
+			includes: "_includes",
+			layouts: "_layouts",
+		}
+	}
+}

--- a/test/global-data/page.webc
+++ b/test/global-data/page.webc
@@ -1,0 +1,4 @@
+---
+layout: layout.webc
+---
+<global-data-component></global-data-component>

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,41 @@ function normalize(str) {
   return str.trim().replace(/\r\n/g, "\n");
 }
 
+test("Global data from component", async t => {
+	let elev = new Eleventy("./test/global-data/page.webc", "./test/global-data/_site", {
+		configPath: "./test/global-data/eleventy.config.js"
+	});
+
+	let results = await elev.toJSON();
+	let [result] = results;
+
+	t.is(normalize(result.content), `<!doctype html>
+<html lang="en">
+<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="description" content>
+		<title></title>
+		<style></style>
+		<script></script>
+	</head>
+	<body>
+		<dl>
+			<dt>key1</dt>
+			<dd>val1</dd>
+			<dt>key2</dt>
+			<dd>val2</dd>
+			<dt>key3</dt>
+			<dd>val3</dd>
+		</dl>
+
+		<style></style>
+		<script></script>
+	
+</body>
+</html>`);
+});
+
 test("Sample page (webc layout)", async t => {
 	let elev = new Eleventy("./test/sample-1/page.webc", "./test/sample-1/_site", {
 		configPath: "./test/sample-1/eleventy.config.js"


### PR DESCRIPTION
## TL;DR

Tried adding a test for using global data in a WebC component.

I think it’s close, but I can’t quite get it to work.


## Background

I **love** WebC…but I’m having a dickens of a time trying to accomplish simple things in an existing project.

I thought to myself, “Self, you can’t seem to access global data in your existing project.  I bet you could look at the tests for the Eleventy WebC plugin and figure out how it works!”

Just looking at the test titles, I couldn’t find a test that did that. (That said, some of the test titles are more descriptive than others, so it’s possible that I missed something.)  So I wrote a new test, but I can’t get it to output the data in any useful way.  I just keep getting `[object Object]`.

“Help me, Obi Wan @zachleat: You’re my only hope!”
—Me