### PR TITLE
Skip bundling within excluded files

### DIFF
--- a/src/eleventyWebcTemplate.js
+++ b/src/eleventyWebcTemplate.js
@@ -151,23 +151,25 @@ module.exports = function(eleventyConfig, options = {}) {
 				// 2.0.0-canary.19+
 				this.addDependencies(inputPath, components);
 
-				// Add CSS to bundle
-				this.config.javascriptFunctions.css(css, "default", data.page.url);
+        if (data.page.url) {
+          // Add CSS to bundle
+          this.config.javascriptFunctions.css(css, "default", data.page.url);
 
-				if(buckets.css) {
-					for(let bucket in buckets.css) {
-						this.config.javascriptFunctions.css(buckets.css[bucket], bucket, data.page.url);
-					}
-				}
+          if(buckets.css) {
+            for(let bucket in buckets.css) {
+              this.config.javascriptFunctions.css(buckets.css[bucket], bucket, data.page.url);
+            }
+          }
 
-				// Add JS to bundle
-				this.config.javascriptFunctions.js(js, "default", data.page.url);
+          // Add JS to bundle
+          this.config.javascriptFunctions.js(js, "default", data.page.url);
 
-				if(buckets.js) {
-					for(let bucket in buckets.js) {
-						this.config.javascriptFunctions.js(buckets.js[bucket], bucket, data.page.url);
-					}
-				}
+          if(buckets.js) {
+            for(let bucket in buckets.js) {
+              this.config.javascriptFunctions.js(buckets.js[bucket], bucket, data.page.url);
+            }
+          }
+        }
 
 				return html;
 			};

--- a/test/excluded-files/page.webc
+++ b/test/excluded-files/page.webc
@@ -1,0 +1,5 @@
+---
+permalink: false
+---
+
+<h1>Testing</h1>

--- a/test/test.js
+++ b/test/test.js
@@ -554,3 +554,20 @@ test("Page with bundled scripts and styles from components", async (t) => {
 </html>`
 	);
 });
+
+test("Excluded files", async (t) => {
+  let elev = new Eleventy(
+    "./test/excluded-files/page.webc",
+    "./test/excluded-files/_site",
+    {
+      configPath: "./test/generic.eleventy.config.js"
+    }
+  );
+
+  let results = await elev.toJSON();
+  let [result] = results;
+  t.is(
+    normalize(result.content),
+    `<h1>Testing</h1>`
+  );
+});


### PR DESCRIPTION
Excluded files (`permalink: false`) won't be rendered, hence bundling of CSS/JS resources is not required. This change not only improves the build performance, it fixes a bug where "renderFile" with WebC fails for excluded files (e.g. drafts).

Here's the high-level flow of what is happening:

- `eleventyWebcTemplate.js` calls the `css` and `js` shortcodes with `data.page.url` as the last parameter. For draft posts, this value is `false`.
- `eleventy.shortcodes.js` checks for `urlOverride || this.page.url`. As the `urlOverride` is `false`, it tries to access `this.page.url`. As `this.page` is `undefined`, this throws an error.

I have added a new test to verify the problem. Revert the code change that I did to see the test failing.

Fixes: #59