### PR TITLE
Feature: "after" option

### DIFF
--- a/src/eleventyWebcTemplate.js
+++ b/src/eleventyWebcTemplate.js
@@ -157,6 +157,10 @@ module.exports = function(eleventyConfig, options = {}) {
 					}
 				}
 
+				if(options.after && typeof options.after === "function") {
+					await options.after(page, { html, css, js, buckets, components });
+				}
+
 				return html;
 			};
 		}


### PR DESCRIPTION
Adds support for `options.after` that runs at the very end of the compile function, directly before returning the template code. 

When using WebC components with this plugin you cannot provide a second override for WebC templates or you cause an error (). Adding this hook inside the options allows you to take the compiled parts of the page and do something with them, alleviate the need for a second override. 

This function mimics the behavior of the before function with the addition of the compiled parts passed as a second argument.