### PR TITLE
Add `homepage` to npm config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,13 @@
 	"devDependencies": {
 		"@11ty/eleventy": "^3.0.0",
 		"ava": "^6.2.0"
-	}
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/11ty/eleventy-plugin-webc"
+	},
+	"bugs": {
+		"url": "https://github.com/11ty/eleventy-plugin-webc/issues"
+	},
+	"homepage": "https://github.com/11ty/eleventy-plugin-webc"
 }


### PR DESCRIPTION
Adds required properties in package.json to enable links on the npm page.